### PR TITLE
CI via github actons

### DIFF
--- a/.github/scripts/checkAuthorData.js
+++ b/.github/scripts/checkAuthorData.js
@@ -1,0 +1,18 @@
+const head = require("ramda").head;
+const core = require("@actions/core");
+const authors = require("../../authors");
+const fs = require("fs");
+const getTweets = require("../../helpers/get-tweets");
+
+const { username } = head(authors);
+
+const infoPath = `./dump/${username}-info.json`;
+const mediaPath = `./dump/${username}-media.json`;
+
+try {
+  if (fs.existsSync(infoPath) && fs.existsSync(mediaPath)) {
+    core.exportVariable("AUTHOR_DATA_EXISTS", true);
+  }
+} catch (err) {
+  console.error(err);
+}

--- a/.github/scripts/checkAuthorReady.js
+++ b/.github/scripts/checkAuthorReady.js
@@ -1,0 +1,18 @@
+const head = require("ramda").head;
+const core = require("@actions/core");
+const underhood = require("../../.underhoodrc.json").underhood;
+const authors = require("../../authors");
+const fs = require("fs");
+const tokens = require("twitter-tokens");
+const getTweets = require("../../helpers/get-tweets");
+
+const { username } = head(authors);
+
+const tweets = [];
+const tweetsSinceId = authors[0].last;
+
+getTweets(tokens, underhood, tweetsSinceId, (err, newTweetsRaw) => {
+  if (err) throw err;
+  const authorReady = newTweetsRaw.length > 1 ? true : false;
+  core.exportVariable("AUTHOR_READY", authorReady);
+});

--- a/.github/scripts/saveAuthorData.js
+++ b/.github/scripts/saveAuthorData.js
@@ -1,0 +1,35 @@
+import log from "../../helpers/log";
+import { outputFile } from "fs-extra";
+import { isEmpty, concat, reverse, last, dissoc, map, head } from "ramda";
+import moment from "moment";
+import dec from "bignum-dec";
+import { sync as rm } from "rimraf";
+
+import { underhood } from "../../.underhoodrc.json";
+import authors from "../../authors";
+
+import tokens from "twitter-tokens";
+import getTweets from "../../helpers/get-tweets";
+import getInfo from "get-twitter-info";
+import saveMedia from "../../helpers/save-media";
+import getFollowers from "get-twitter-followers";
+import twitterMentions from "twitter-mentions";
+
+import ensureFilesForFirstUpdate from "../../helpers/ensure-author-files";
+import getAuthorArea from "../../helpers/get-author-area";
+import saveAuthorArea from "../../helpers/save-author-area";
+
+import { writeFile } from "fs";
+
+const { username } = head(authors);
+
+getInfo(tokens, underhood, (err, info) => {
+  if (err) throw err;
+  saveAuthorArea(username, "info", info);
+});
+
+// rm(`./dump/images/${username}*`);
+saveMedia(tokens, underhood, username, (err, media) => {
+  if (err) throw err;
+  saveAuthorArea(username, "media", media);
+});

--- a/.github/scripts/transferShift.js
+++ b/.github/scripts/transferShift.js
@@ -1,0 +1,74 @@
+import log from "../../helpers/log";
+import { outputFile } from "fs-extra";
+import { isEmpty, concat, reverse, last, dissoc, map, head } from "ramda";
+import moment from "moment";
+import dec from "bignum-dec";
+import { sync as rm } from "rimraf";
+
+import { underhood } from "../../.underhoodrc.json";
+import authors from "../../authors";
+
+import tokens from "twitter-tokens";
+import getTweets from "../../helpers/get-tweets";
+import getInfo from "get-twitter-info";
+import saveMedia from "../../helpers/save-media";
+import getFollowers from "get-twitter-followers";
+import twitterMentions from "twitter-mentions";
+
+import ensureFilesForFirstUpdate from "../../helpers/ensure-author-files";
+import getAuthorArea from "../../helpers/get-author-area";
+import saveAuthorArea from "../../helpers/save-author-area";
+
+const { username } = head(authors);
+
+// ensureFilesForFirstUpdate(username, ["tweets"]);
+
+import { writeFile } from "fs";
+
+const newUsername = process.argv.slice(2)[0]; //new author
+
+if (!newUsername) {
+  console.log("Please provide a username of a person who will take the shift");
+  process.exit();
+}
+
+const tweets = [];
+const mentions = [];
+
+const saveLastTweetId = (tweets) => {
+  const lastTweetId = isEmpty(tweets) ? tweetsSinceId : last(tweets).id_str;
+
+  /* Assign new author */
+
+  const newStartDate = moment(new Date(authors[0].start))
+    .add(1, "w")
+    .format("DD MMMM YYYY");
+
+  const newAuthors = [
+    { username: newUsername, start: newStartDate, post: false },
+    Object.assign(authors.shift(), { last: lastTweetId, post: true }),
+    ...authors,
+  ];
+
+  writeFile(
+    `./authors.js`,
+    "export default " + JSON.stringify(newAuthors, null, 2),
+    (err) => console.log("err", err)
+  );
+};
+
+const tweetsSinceId = authors[1].last;
+
+/* Save data for the author who is finished */
+getTweets(tokens, underhood, tweetsSinceId, (err, newTweetsRaw) => {
+  if (err) throw err;
+  const concattedTweets = concat(tweets, reverse(newTweetsRaw));
+  saveAuthorArea(username, "tweets", { tweets: concattedTweets });
+  saveLastTweetId(concattedTweets);
+});
+
+getFollowers(tokens, underhood, (err, followersWithStatuses) => {
+  if (err) throw err;
+  const followers = map(dissoc("status"), followersWithStatuses);
+  saveAuthorArea(username, "followers", { followers });
+});

--- a/.github/workflows/author-data.yml
+++ b/.github/workflows/author-data.yml
@@ -1,0 +1,156 @@
+name: Check and save author data
+
+# Check if the new author had updated data in the profile, and once it looks updated - collect image and description.
+on: 
+  schedule:
+    - cron: "0 * * * *"
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'authors.js'
+  workflow_dispatch:
+    
+jobs:
+  check_author_data_exists:
+    runs-on: ubuntu-latest
+
+    outputs:
+      result: ${{ env.AUTHOR_DATA_EXISTS }}
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: "8"
+          
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: CHeck if author data exists
+        run: |
+          npm run check:author:data
+        env: 
+            TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+            TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+            TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+            TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+            
+            
+  check_author_ready:
+    runs-on: ubuntu-latest
+    needs: check_author_data_exists
+    if: needs.check_author_data_exists.outputs.result != 'true'
+
+    outputs:
+      result: ${{ env.AUTHOR_READY }}
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: "8"
+          
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install Dependencies
+        run: npm install
+
+    
+      - name: CHeck if author had started shift
+        run: |
+          npm run check:author:ready
+        env: 
+            TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+            TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+            TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+            TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+      
+        
+  save_author_data:
+    runs-on: ubuntu-latest
+    needs: check_author_ready
+    if: needs.check_author_ready.outputs.result == 'true'
+    env: 
+        TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+        TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+        TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+        TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: "8"
+          
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Save start data
+        run: npm run save:author:data
+      
+      
+      - name: Commit user data
+        run: |
+          git add dump/**
+          git reset -- package-lock.json
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m 'save user data'
+          git push
+        
+      - name: Build product
+        run: npm run build
+                    
+      - name: Deploy product
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          folder: ./dist
+          branch: gh-pages                    
+     

--- a/.github/workflows/shift-transfer.yml
+++ b/.github/workflows/shift-transfer.yml
@@ -1,0 +1,56 @@
+name: Transfer shift to new author
+
+# Check if the new author had updated data, and once it looks updated - collect image and description
+on: 
+  workflow_dispatch:
+    inputs: 
+      username:
+          description: 'Who is taking the shift?'     
+          required: true
+jobs:
+  shift_transfer:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: "8"
+          
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: End shift for previous author/start for next one
+        run: |
+          npm run shift:transfer ${{ github.event.inputs.username }}
+        env: 
+            TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+            TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+            TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+            TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+                  
+      - name: Save and commit data
+        run: |
+          git add dump/**
+          git add authors.js
+          git reset -- package-lock.json
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m 'transfer shift to ${{  github.event.inputs.username }}'
+          git push

--- a/authors.js
+++ b/authors.js
@@ -2,7 +2,7 @@
 
 export default [
     { username: 'oratblevat',  start: '14 June 2021', first: '1404158882587582468', post: false },
-    { username: 'senbermyau',  start: '7 June 2021', first: '1401785082810077200' },
+    { username: 'senbermyau',  start: '7 June 2021', first: '1401785082810077200', last: "1404197948167278598" },
     { username: 'me_Noemi',  start: '31 May 2021', first: '1399273927227199500' },
     { username: 'ablkmv',  start: '24 May 2021', first: '1396869162849476610' },
     { username: '2dead4lines',  start: '17 May 2021', first: '1394599630202151000' },

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -121,12 +121,14 @@ task('rss', done => {
   const feed = new RSS(underhood.site);
   const authorsToPost = authors.filter(author => author.post !== false);
   authorsToPost.forEach(author => {
-    feed.item({
-      title: author.username,
-      description: render(firstTweet(author)),
-      url: `https://jsunderhood.ru/${author.username}/`,
-      date: firstTweet(author).created_at,
-    });
+    if (author.tweets.length > 0) {
+      feed.item({
+        title: author.username,
+        description: render(firstTweet(author)),
+        url: `https://jsunderhood.ru/${author.username}/`,
+        date: firstTweet(author).created_at,
+      });
+    }
   });
   output('dist/rss.xml', feed.xml({ indent: true }), done);
 });

--- a/layouts/author.jade
+++ b/layouts/author.jade
@@ -5,8 +5,8 @@ block meta
   meta(name="og:url"          content=site.site_url + author.username + "/")
   if (author.media && author.media.image)
     meta(name="og:image"        content=site.site_url + author.media.image.replace('./', ''))
-  meta(property="description" content=author.tweets[0].text)
-  meta(name="og:description"  content=author.tweets[0].text)
+  meta(property="description" content=author.tweets[0] ? author.tweets[0].text : "")
+  meta(name="og:description"  content=author.tweets[0] ? author.tweets[0].text : "")
 
 block headerTitle
   a(href="/")= underhood.underhood
@@ -25,7 +25,8 @@ block content
               small: small: a(href="https://twitter.com/" + author.username)
                 span.glyphicon.glyphicon-new-window
             p
-              i= helpers.authorRender.d(author.tweets[0].created_at)
+              if author.tweets.length > 0
+                i= helpers.authorRender.d(author.tweets[0].created_at)
               if author.info.location
                 = ", "
                 span.glyphicon.glyphicon-map-marker

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "scripts": {
     "migrate": "babel-node migration",
     "update": "babel-node update",
+    "shift:transfer": "babel-node .github/scripts/transferShift",
+    "save:author:data": "babel-node .github/scripts/saveAuthorData",
+    "check:author:ready": "babel-node .github/scripts/checkAuthorReady",
+    "check:author:data": "babel-node .github/scripts/checkAuthorData",
+    "build": "gulp build",
     "deploy": "gulp deploy",
     "deploy:ci": "npm-run-all git-setup:ci update save deploy",
     "pretest": "gulp build",
@@ -78,6 +83,7 @@
     "webpack": "^1.12.4"
   },
   "devDependencies": {
+    "@actions/core": "^1.4.0",
     "assert": "^1.3.0",
     "babel-eslint": "^4.1.3",
     "cheerio": "^0.19.0",


### PR DESCRIPTION
Added 2 workflows:
1.  __Transfer shift__ - Runs manually and takes username of new author as an argument.
It will save data of the author who had finished his shift add an entry with new username to `authors.js`.
2. __Check author data__ - runs every hour, consists of 3 steps:
    - Check if author's data was already saved. If files exist, do nothing.
    - Check if author had written at least one tweet. This is an indicator that the author had edited avatar and description, and data can be saved.
    - Save author data and also rebuild and re-deploy the website.

Didn't remove any old scripts, everything should be backward compatible.
Up to further discussion if we want to redeploy site more often, we can add one more workflow for that.