### PR TITLE
remove check-if-data-exists job

### DIFF
--- a/.github/workflows/author-data.yml
+++ b/.github/workflows/author-data.yml
@@ -11,52 +11,9 @@ on:
       - 'authors.js'
   workflow_dispatch:
     
-jobs:
-  check_author_data_exists:
-    runs-on: ubuntu-latest
-
-    outputs:
-      result: ${{ env.AUTHOR_DATA_EXISTS }}
-    
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Install NodeJS
-        uses: actions/setup-node@v2
-        with:
-          node-version: "8"
-          
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Install Dependencies
-        run: npm install
-
-      - name: CHeck if author data exists
-        run: |
-          npm run check:author:data
-        env: 
-            TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
-            TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-            TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
-            TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
-            
-            
+jobs:      
   check_author_ready:
     runs-on: ubuntu-latest
-    needs: check_author_data_exists
-    if: needs.check_author_data_exists.outputs.result != 'true'
 
     outputs:
       result: ${{ env.AUTHOR_READY }}


### PR DESCRIPTION
Super-qiuick fix for an issue with author data update.
Basically I just removed a check, if data exists already. Now it's saved and redeployed every hour no matter what.
We can set it less frequent of course. We can check file contents every time of course, and redeploy only if data was changed, I just don't know if it's needed.
I hope it won't be a problem for API limits? It's just 2 request at a time, but dunno...

_P.S. By the way, the last author forgot to change his description_
